### PR TITLE
Gracefully handle missing Firebase config

### DIFF
--- a/firebase-auth.js
+++ b/firebase-auth.js
@@ -4,10 +4,16 @@ import { GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged } from
 const provider = new GoogleAuthProvider();
 let currentUser = null;
 
-onAuthStateChanged(auth, (u) => {
-  currentUser = u || null;
-  window.dispatchEvent(new CustomEvent('auth:changed', { detail: { user: currentUser } }));
-});
+if (auth) {
+  onAuthStateChanged(auth, (u) => {
+    currentUser = u || null;
+    window.dispatchEvent(new CustomEvent('auth:changed', { detail: { user: currentUser } }));
+  });
+} else {
+  // running without firebase config; stay logged out
+  console.warn('[auth] Firebase Auth not initialized. Running in offline mode.');
+  currentUser = null;
+}
 
 export function getUser(){ return currentUser; }
 export async function waitForUser(timeoutMs=5000){
@@ -20,6 +26,10 @@ export async function waitForUser(timeoutMs=5000){
 }
 
 export async function firebaseLogin(){
+  if (!auth) {
+    alert('Kan ikke logge ind: Firebase Auth er ikke initialiseret.');
+    return null;
+  }
   try {
     const res = await signInWithPopup(auth, provider);
     console.info('[auth] signed in as', res.user?.email);
@@ -32,5 +42,6 @@ export async function firebaseLogin(){
 }
 
 export async function firebaseLogout(){
+  if (!auth) return;
   try { await signOut(auth); } catch (e) { console.error(e); }
 }

--- a/notesService.js
+++ b/notesService.js
@@ -10,5 +10,9 @@ export async function createNote({ title, body }){
     alert('Du skal være logget ind for at oprette noter.');
     return;
   }
+  if (!db) {
+    alert('Firestore er ikke initialiseret. Noten blev ikke gemt.');
+    return;
+  }
   await addDoc(userNotesCol(user.uid), { title, body, createdAt: serverTimestamp() });
 }


### PR DESCRIPTION
## Summary
- Prevent firebase-auth module from crashing when Firebase isn't initialized
- Avoid note creation when Firestore isn't available

## Testing
- `npm run build` *(fails: VITE_FIREBASE_CONFIG env var missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f2fc9e7348333bd8299b8ad07b6ca